### PR TITLE
Some dbgshim usage changes.

### DIFF
--- a/metadata.h
+++ b/metadata.h
@@ -146,13 +146,18 @@ void enum_types(ICorDebugModule *module)
                 printf("\tBreakpoint being created\n");
                 ICorDebugFunction *mainFunc = NULL;
                 module->GetFunctionFromToken(methodTokens[j], &mainFunc);
-                ICorDebugFunctionBreakpoint *bp = NULL;
-                mainFunc->CreateBreakpoint(&bp);
-                bp->Activate(TRUE);
 
+                ICorDebugFunctionBreakpoint *bp = NULL;
+                HRESULT hr = mainFunc->CreateBreakpoint(&bp);
+                if (hr == 0)
+                {
+                    bp->Activate(TRUE);
+                }
+                else 
+                {
+                    printf("\tCreate breakpoint %s FAILED %08x\n", to_ascii(name), hr);
+                }
             }
         }
-
-
     }
 }

--- a/metadata.h
+++ b/metadata.h
@@ -155,7 +155,7 @@ void enum_types(ICorDebugModule *module)
                 }
                 else 
                 {
-                    printf("\tCreate breakpoint %s FAILED %08x\n", to_ascii(name), hr);
+                    printf("\tCreate breakpoint %s FAILED %08x\n", (char *)name, hr);
                 }
             }
         }


### PR DESCRIPTION
EnumerateCLRs (and CloseCLREnumeration) needed to be called to get the path to CreateVersionStringFromModule. Also printed an error message when CreateBreakpoint fails (usually on non-IL methods/pinvokes).
